### PR TITLE
Add calleeFunc as an argument to the command

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -32,16 +32,16 @@ const (
 
 // ==[ type def/func: analysis   ]===============================================
 type renderOpts struct {
-	cacheDir   string
-	focus      string
-	group      []string
-	ignore     []string
-	include    []string
-	limit      []string
-	nointer    bool
-	refresh    bool
-	nostd      bool
-	algo       CallGraphType
+	cacheDir  string
+	focus     string
+	group     []string
+	ignore    []string
+	include   []string
+	limit     []string
+	nointer   bool
+	refresh   bool
+	nostd     bool
+	algo      CallGraphType
 	calleeFunc []string
 }
 
@@ -131,15 +131,15 @@ func (a *analysis) DoAnalysis(
 
 func (a *analysis) OptsSetup() {
 	a.opts = &renderOpts{
-		cacheDir:   *cacheDir,
-		focus:      *focusFlag,
-		group:      []string{*groupFlag},
-		ignore:     []string{*ignoreFlag},
-		include:    []string{*includeFlag},
-		limit:      []string{*limitFlag},
-		nointer:    *nointerFlag,
-		nostd:      *nostdFlag,
-		calleeFunc: strings.Split(*calleeFuncFlag, ","),
+		cacheDir: *cacheDir,
+		focus:    *focusFlag,
+		group:    []string{*groupFlag},
+		ignore:   []string{*ignoreFlag},
+		include:  []string{*includeFlag},
+		limit:    []string{*limitFlag},
+		nointer:  *nointerFlag,
+		nostd:    *nostdFlag,
+		calleeFunc: []string{*calleeFuncFlag},
 	}
 }
 
@@ -148,6 +148,7 @@ func (a *analysis) ProcessListArgs() (e error) {
 	var ignorePaths []string
 	var includePaths []string
 	var limitPaths []string
+	var calleeFunc []string
 
 	for _, g := range strings.Split(a.opts.group[0], ",") {
 		g := strings.TrimSpace(g)
@@ -182,10 +183,18 @@ func (a *analysis) ProcessListArgs() (e error) {
 		}
 	}
 
+	for _, f := range strings.Split(a.opts.calleeFunc[0], ",") {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			calleeFunc = append(calleeFunc, f)
+		}
+	}
+
 	a.opts.group = groupBy
 	a.opts.ignore = ignorePaths
 	a.opts.include = includePaths
 	a.opts.limit = limitPaths
+	a.opts.calleeFunc = calleeFunc
 
 	return
 }
@@ -217,8 +226,8 @@ func (a *analysis) OverrideByHTTP(r *http.Request) {
 	if inc := r.FormValue("include"); inc != "" {
 		a.opts.include[0] = inc
 	}
-	if cf := r.FormValue("calleeFunc"); cf != "" {
-		a.opts.calleeFunc = strings.Split(cf, ",")
+	if callee := r.FormValue("calleeFunc"); callee != "" {
+		a.opts.calleeFunc = strings.Split(callee, ",")
 	}
 	return
 }

--- a/analysis.go
+++ b/analysis.go
@@ -32,16 +32,17 @@ const (
 
 // ==[ type def/func: analysis   ]===============================================
 type renderOpts struct {
-	cacheDir string
-	focus    string
-	group    []string
-	ignore   []string
-	include  []string
-	limit    []string
-	nointer  bool
-	refresh  bool
-	nostd    bool
-	algo     CallGraphType
+	cacheDir   string
+	focus      string
+	group      []string
+	ignore     []string
+	include    []string
+	limit      []string
+	nointer    bool
+	refresh    bool
+	nostd      bool
+	algo       CallGraphType
+	calleeFunc []string
 }
 
 // mainPackages returns the main packages to analyze.
@@ -130,14 +131,15 @@ func (a *analysis) DoAnalysis(
 
 func (a *analysis) OptsSetup() {
 	a.opts = &renderOpts{
-		cacheDir: *cacheDir,
-		focus:    *focusFlag,
-		group:    []string{*groupFlag},
-		ignore:   []string{*ignoreFlag},
-		include:  []string{*includeFlag},
-		limit:    []string{*limitFlag},
-		nointer:  *nointerFlag,
-		nostd:    *nostdFlag,
+		cacheDir:   *cacheDir,
+		focus:      *focusFlag,
+		group:      []string{*groupFlag},
+		ignore:     []string{*ignoreFlag},
+		include:    []string{*includeFlag},
+		limit:      []string{*limitFlag},
+		nointer:    *nointerFlag,
+		nostd:      *nostdFlag,
+		calleeFunc: strings.Split(*calleeFuncFlag, ","),
 	}
 }
 
@@ -215,6 +217,9 @@ func (a *analysis) OverrideByHTTP(r *http.Request) {
 	if inc := r.FormValue("include"); inc != "" {
 		a.opts.include[0] = inc
 	}
+	if cf := r.FormValue("calleeFunc"); cf != "" {
+		a.opts.calleeFunc = strings.Split(cf, ",")
+	}
 	return
 }
 
@@ -267,6 +272,7 @@ func (a *analysis) Render() ([]byte, error) {
 		a.opts.group,
 		a.opts.nostd,
 		a.opts.nointer,
+		a.opts.calleeFunc,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("processing failed: %v", err)

--- a/main.go
+++ b/main.go
@@ -1,4 +1,3 @@
-// go-callvis: a tool to help visualize the call graph of a Go program.
 package main
 
 import (
@@ -30,22 +29,23 @@ Flags:
 `
 
 var (
-	focusFlag     = flag.String("focus", "main", "Focus specific package using name or import path.")
-	groupFlag     = flag.String("group", "pkg", "Grouping functions by packages and/or types [pkg, type] (separated by comma)")
-	limitFlag     = flag.String("limit", "", "Limit package paths to given prefixes (separated by comma)")
-	ignoreFlag    = flag.String("ignore", "", "Ignore package paths containing given prefixes (separated by comma)")
-	includeFlag   = flag.String("include", "", "Include package paths with given prefixes (separated by comma)")
-	nostdFlag     = flag.Bool("nostd", false, "Omit calls to/from packages in standard library.")
-	nointerFlag   = flag.Bool("nointer", false, "Omit calls to unexported functions.")
-	testFlag      = flag.Bool("tests", false, "Include test code.")
-	graphvizFlag  = flag.Bool("graphviz", false, "Use Graphviz's dot program to render images.")
-	httpFlag      = flag.String("http", ":7878", "HTTP service address.")
-	skipBrowser   = flag.Bool("skipbrowser", false, "Skip opening browser.")
-	outputFile    = flag.String("file", "", "output filename - omit to use server mode")
-	outputFormat  = flag.String("format", "svg", "output file format [svg | png | jpg | ...]")
-	cacheDir      = flag.String("cacheDir", "", "Enable caching to avoid unnecessary re-rendering, you can force rendering by adding 'refresh=true' to the URL query or emptying the cache directory")
-	callgraphAlgo = flag.String("algo", string(CallGraphTypeStatic), fmt.Sprintf("The algorithm used to construct the call graph. Possible values inlcude: %q, %q, %q",
+	focusFlag       = flag.String("focus", "main", "Focus specific package using name or import path.")
+	groupFlag       = flag.String("group", "pkg", "Grouping functions by packages and/or types [pkg, type] (separated by comma)")
+	limitFlag       = flag.String("limit", "", "Limit package paths to given prefixes (separated by comma)")
+	ignoreFlag      = flag.String("ignore", "", "Ignore package paths containing given prefixes (separated by comma)")
+	includeFlag     = flag.String("include", "", "Include package paths with given prefixes (separated by comma)")
+	nostdFlag       = flag.Bool("nostd", false, "Omit calls to/from packages in standard library.")
+	nointerFlag     = flag.Bool("nointer", false, "Omit calls to unexported functions.")
+	testFlag        = flag.Bool("tests", false, "Include test code.")
+	graphvizFlag    = flag.Bool("graphviz", false, "Use Graphviz's dot program to render images.")
+	httpFlag        = flag.String("http", ":7878", "HTTP service address.")
+	skipBrowser     = flag.Bool("skipbrowser", false, "Skip opening browser.")
+	outputFile      = flag.String("file", "", "output filename - omit to use server mode")
+	outputFormat    = flag.String("format", "svg", "output file format [svg | png | jpg | ...]")
+	cacheDir        = flag.String("cacheDir", "", "Enable caching to avoid unnecessary re-rendering, you can force rendering by adding 'refresh=true' to the URL query or emptying the cache directory")
+	callgraphAlgo   = flag.String("algo", string(CallGraphTypeStatic), fmt.Sprintf("The algorithm used to construct the call graph. Possible values inlcude: %q, %q, %q",
 		CallGraphTypeStatic, CallGraphTypeCha, CallGraphTypeRta))
+	calleeFuncFlag  = flag.String("calleeFunc", "", "Specify the functions to be used as callee functions (comma-separated).")
 
 	debugFlag   = flag.Bool("debug", false, "Enable verbose log.")
 	versionFlag = flag.Bool("version", false, "Show version and exit.")

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// go-callvis: a tool to help visualize the call graph of a Go program.
 package main
 
 import (

--- a/output.go
+++ b/output.go
@@ -32,6 +32,7 @@ func printOutput(
 	groupBy []string,
 	nostd,
 	nointer bool,
+	calleeFunc []string,
 ) ([]byte, error) {
 	var groupType, groupPkg bool
 	for _, g := range groupBy {
@@ -137,6 +138,27 @@ func printOutput(
 			return true
 		}
 		return false
+	}
+
+	var containsCalleeFunc = func(node *callgraph.Node) bool {
+		for _, funcName := range calleeFunc {
+			if strings.Contains(node.Func.Name(), funcName) {
+				return true
+			}
+		}
+		return false
+	}
+
+	var traverseIn = func(node *callgraph.Node, visited map[*callgraph.Node]bool) {
+		if visited[node] {
+			return
+		}
+		visited[node] = true
+		for _, edge := range node.In {
+			if !isSynthetic(edge) {
+				traverseIn(edge.Caller, visited)
+			}
+		}
 	}
 
 	count := 0

--- a/output.go
+++ b/output.go
@@ -32,7 +32,7 @@ func printOutput(
 	groupBy []string,
 	nostd,
 	nointer bool,
-	calleeFunc []string,
+	calleeFuncs []string,
 ) ([]byte, error) {
 	var groupType, groupPkg bool
 	for _, g := range groupBy {
@@ -141,25 +141,53 @@ func printOutput(
 	}
 
 	var containsCalleeFunc = func(node *callgraph.Node) bool {
-		for _, funcName := range calleeFunc {
-			if strings.Contains(node.Func.Name(), funcName) {
+		if node == nil || node.Func == nil {
+			return false
+		}
+		for _, funcName := range calleeFuncs {
+			if strings.Contains(strings.ToLower(node.Func.Name()), strings.ToLower(funcName)) {
 				return true
 			}
 		}
 		return false
 	}
 
-	var traverseIn = func(node *callgraph.Node, visited map[*callgraph.Node]bool) {
+	var traverseCaller func(node *callgraph.Node, visited map[*callgraph.Node]bool) map[*ssa.Function]*callgraph.Node
+	traverseCaller = func(node *callgraph.Node, visited map[*callgraph.Node]bool) map[*ssa.Function]*callgraph.Node {
+		nodes := map[*ssa.Function]*callgraph.Node{}
 		if visited[node] {
-			return
+			return nodes
 		}
 		visited[node] = true
+		nodes[node.Func] = node
 		for _, edge := range node.In {
 			if !isSynthetic(edge) {
-				traverseIn(edge.Caller, visited)
+				res := traverseCaller(edge.Caller, visited)
+				for k, v := range res {
+					nodes[k] = v
+				}
 			}
 		}
+		return nodes
 	}
+
+	calleeNodes := map[*ssa.Function]*callgraph.Node{}
+	var addCalleeNodes = func(edge *callgraph.Edge) error {
+		callee := edge.Callee
+		if containsCalleeFunc(callee) {
+			calleeNodes[callee.Func] = callee
+		}
+		return nil
+	}
+	callgraph.GraphVisitEdges(cg, addCalleeNodes)
+	filteredNodes := map[*ssa.Function]*callgraph.Node{}
+	for _, node := range calleeNodes {
+		res := traverseCaller(node, make(map[*callgraph.Node]bool))
+		for k, v := range res {
+			filteredNodes[k] = v
+		}
+	}
+	cg.Nodes = filteredNodes
 
 	count := 0
 	err := callgraph.GraphVisitEdges(cg, func(edge *callgraph.Edge) error {


### PR DESCRIPTION
Add calleeFunc as an argument to the command to filter and display functions calling specified functions.

* **main.go**
  - Add a new flag `calleeFuncFlag` to accept multiple comma-separated strings.
* **output.go**
  - Update the `printOutput` function to accept a new argument `calleeFunc`.
  - Add logic to recursively traverse the `In` of any `Node` whose name contains the function specified in `calleeFunc`.
  - Display all functions that are directly or indirectly calling the functions specified in `calleeFunc`.
* **analysis.go**
  - Update the `Render` method to pass the `calleeFunc` argument to the `printOutput` function.
  - Update the `OptsSetup` method to include `calleeFunc`.
  - Update the `ProcessListArgs` method to handle `calleeFunc`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yyamada12/go-callviz?shareId=81eb7b72-33de-478d-abe3-c85d006220ea).